### PR TITLE
fix: skip wildcard actions in IAM policies to avoid KeyError

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,13 @@ If AWS changes the page layout or internal structure:
 
 If you notice incorrect or missing data, check the [IAM actions documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_actions-resources-contextkeys.html) for changes.
 
+### Wildcard action patterns are currently ignored
+
+Actions containing wildcards such as `"s3:*"` or `"*"` in IAM policies are currently ignored.  
+The tool logs a warning when such patterns are encountered and skips them from analysis.
+
+> This is to prevent runtime errors and undefined behavior. Future versions may support expanding service-level wildcard actions like `"s3:*"` into individual actions.
+
 ---
 
 ## License

--- a/iam_action_catalog/iam.py
+++ b/iam_action_catalog/iam.py
@@ -12,6 +12,7 @@ from mypy_boto3_iam import IAMClient
 from mypy_boto3_iam.type_defs import (
     GetServiceLastAccessedDetailsRequestTypeDef,
     ListAttachedRolePoliciesRequestTypeDef,
+    PolicyDocumentStatementTypeDef,
     ServiceLastAccessedTypeDef,
     TrackedActionLastAccessedTypeDef,
 )
@@ -275,6 +276,7 @@ def _get_actions_for_policy(
     if not policy_document:
         return {}
 
+    statement: list[PolicyDocumentStatementTypeDef]
     if isinstance(policy_document, str):
         statement = json.loads(policy_document)["Statement"]
     else:
@@ -286,6 +288,11 @@ def _get_actions_for_policy(
         if not isinstance(actions, list):
             actions = [actions]
         for action in actions:
+            if "*" in action:
+                logger.warning(
+                    f"[policy({policy_arn})]: it contains a statement with at least one action that includes *. This is currently ignored."
+                )
+                continue
             ns, action_name = action.split(":", 1)
             if ns not in ret:
                 ret[ns] = []


### PR DESCRIPTION
Previously, IAM actions containing "*" (e.g. "s3:*" or "*") caused a KeyError when looking up the action in the catalog. This patch skips such wildcard actions entirely and logs a warning per policy, ensuring stability and clarity until proper wildcard expansion is supported.

Note: wildcard support may be added in a future enhancement.